### PR TITLE
Add spacing to exec shortcode

### DIFF
--- a/layouts/layouts/shortcodes/execs.html
+++ b/layouts/layouts/shortcodes/execs.html
@@ -12,12 +12,12 @@
   <div class="col">
     <h3>{{ .position }}</h3>
     <div>
-      <h4 class="d-inline fs-6 fw-bold" style="font: inherit">Name:</h4>
+      <h4 class="d-inline fs-6 fw-bold" style="font: inherit">Name: </h4>
       <span>{{ .name }}</span>
     </div>
     {{ with .email }}
     <div>
-      <h4 class="d-inline fs-6 fw-bold" style="font: inherit">Email:</h4>
+      <h4 class="d-inline fs-6 fw-bold" style="font: inherit">Email: </h4>
       <code>{{ replace (replace . "@" " [at] ") "." " [dot] " }}</code>
     </div>
     {{ end }}


### PR DESCRIPTION
This PR adds spacing to the `execs` shortcode as per [this PR comment](https://github.com/ubccsss/ubccsss.org/pull/194#issuecomment-1158369908).

Previously, the spacing looked like:
![image](https://user-images.githubusercontent.com/45278276/175828078-ff494a40-c5bf-487f-81dc-2fc6281d4508.png)

Now, it looks like:
![image](https://user-images.githubusercontent.com/45278276/175828091-1dab226e-735f-4164-8ea7-776e22679346.png)

I noticed that this issue doesn't appear in local development, and only in the deploy preview, even though both should be based on the latest version of this theme + Bootstrap. We might want to check what exactly the Netlify deploy previews are pulling - we might have missed something when migrating the theme to its own repo. 