### PR TITLE
Add history navigation to officer page

### DIFF
--- a/layouts/about/current-officers.html
+++ b/layouts/about/current-officers.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-{{ $currentOfficers := index (sort .RegularPages "Title" "desc") 0 }}
+{{ $currentOfficers := index (sort .RegularPages "Title" "asc") 0 }}
 
 <header>
     {{ partial "breadcrumb/breadcrumbs" . }}
@@ -25,6 +25,8 @@
         </ul>
         {{ end }}
     {{ end }}
+
+    {{ partial "pages/pager" . }}
 </article>
 
 {{ end }}


### PR DESCRIPTION
This PR adds the navigation bar on the exec page that shows the past execs to the officers page as well.

This would go at the bottom of every officers page:
![image](https://user-images.githubusercontent.com/45278276/175828576-939982c6-0ea5-424a-96ec-af6c1af01103.png)
