### PR TITLE
Add officer photo shortcode

### DIFF
--- a/layouts/shortcodes/officers.html
+++ b/layouts/shortcodes/officers.html
@@ -1,0 +1,20 @@
+<div class="row">
+  <div class="col-auto">
+    <img
+      class="rounded-circle"
+      height="100"
+      width="100"
+      {{ $pfp := resources.Get (index .Params 2) }}
+      src="{{ $pfp.Permalink }}"
+      alt="{{ index .Params 0 }}"
+      loading="lazy"
+      style="object-fit: cover"
+    />
+  </div>
+  <div class="col d-flex flex-col align-items-center">
+    <div>
+      <h3>{{ index .Params 0 }}</h3>
+      <p>{{ index .Params 1 }}</p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This PR adds a shortcode for the officer profiles. It's copied from the exec profile layout, and looks like this:

![image](https://user-images.githubusercontent.com/45278276/178861685-cb528767-8f38-4ecf-b834-431a0c15d4c2.png)
