### PR TITLE
Use 0.5ch margin instead of space

### DIFF
--- a/layouts/shortcodes/execs.html
+++ b/layouts/shortcodes/execs.html
@@ -12,12 +12,12 @@
   <div class="col">
     <h3>{{ .position }}</h3>
     <div>
-      <h4 class="d-inline fs-6 fw-bold" style="font: inherit">Name: </h4>
+      <h4 class="d-inline fs-6 fw-bold" style="font: inherit; margin-right: 0.5ch">Name:</h4>
       <span>{{ .name }}</span>
     </div>
     {{ with .email }}
     <div>
-      <h4 class="d-inline fs-6 fw-bold" style="font: inherit">Email: </h4>
+      <h4 class="d-inline fs-6 fw-bold" style="font: inherit; margin-right: 0.5ch">Email:</h4>
       <code>{{ replace (replace . "@" " [at] ") "." " [dot] " }}</code>
     </div>
     {{ end }}


### PR DESCRIPTION
Asad and I have both tried to add spacing in the exec shortcode (#5, #9) - it always appears to work locally but not in production. I have a hunch this is because the `hugo build` process strips out any extra spaces in the HTML.

I've added `0.5ch` of right padding instead to emulate a space, this should be more robust :crossed_fingers:. 

(Note that for some reason on local the fields appear to have extra space, but they should look like this on production: 
![image](https://user-images.githubusercontent.com/45278276/187093478-7af29a0a-4350-4e53-a2cc-eb23d4d44f4c.png)
